### PR TITLE
Minimax

### DIFF
--- a/Pokemon-Showdown/Pokemon-Showdown-Bot/features/battle/battle-ai/modules/minimax-bot.js
+++ b/Pokemon-Showdown/Pokemon-Showdown-Bot/features/battle/battle-ai/modules/minimax-bot.js
@@ -15,10 +15,9 @@ const SPECIAL_CHARS = /[%\s\.'-]/g
 var getBestMove = exports.getBestMove = (battle, decisions) => {
     let pokemonList = battle.request.side.pokemon
     let ourPokemon = battle.self.active[0]
-    let currPokemon = pokemon.filter(pokemon => pokemon.active)[0]
+    let ourName = formatName(ourPokemon.name)
     let foePokemon = battle.foe.active[0]
     let foeName = formatName(foePokemon.name)
-    // console.log(foePokemon)
 
     // Get valid moves sorted by maxpp
     let moves = battle.request.active[0].moves.map((move, i) => {
@@ -91,11 +90,12 @@ var getBestMove = exports.getBestMove = (battle, decisions) => {
         var ret = SYNC_REQUEST('POST', 'http://127.0.0.1:5000/getaction', {
             json: {
                 generation: GEN,
-                currPokemon: POKEDEX[getPokemonName(currPokemon)].num,
+                currPokemon: POKEDEX[ourName].num,
                 ourPokemon: ourPokedexNumbers,
                 theirPokemon: POKEDEX[foeName].num,
                 ourHp: ourCondition,
                 theirHp: foePokemon.hp/100,
+                theirStatus: foePokemon.status,
                 ourMoves: ourMoves,
                 theirMoves: theirMoves,
                 ourStats: ourBaseStats,
@@ -134,25 +134,29 @@ var getBestMove = exports.getBestMove = (battle, decisions) => {
                 return nextPokemon[0]
             }
         } else {
+            for (var property in foePokemon){
+                console.log(property + ": " + foePokemon[property]);
+            }
             console.log("ERROR IN minimaxserver.py. ACTION NOT RETURNED")
             console.log({
                 generation: GEN,
-                currPokemon: POKEDEX[getPokemonName(currPokemon)].num,
+                currPokemon: POKEDEX[ourName].num,
                 ourPokemon: ourPokedexNumbers,
                 theirPokemon: POKEDEX[foeName].num,
                 ourHp: ourCondition,
                 theirHp: foePokemon.hp/100,
+                theirStatus: foePokemon.status,
                 ourMoves: ourMoves,
                 theirMoves: theirMoves,
                 ourStats: ourBaseStats,
                 ourLevel: ourPokemon.level,
-                theirLevel: foePokemon.level
+                theirLevel: foePokemon.level,
                 ourTypes: ourTypes,
                 theirTypes: foePokemon.template.types,
                 ourBaseStats: ourPokemon.template.baseStats,
                 theirBaseStats: foePokemon.template.baseStats,
                 ourBoosts: ourPokemon.boosts,
-                theirBoosts: ourPokemon.boosts
+                theirBoosts: foePokemon.boosts
             })
         }
     } catch (error) {

--- a/Pokemon-Showdown/Pokemon-Showdown-Bot/features/battle/battle-ai/modules/minimax-bot.js
+++ b/Pokemon-Showdown/Pokemon-Showdown-Bot/features/battle/battle-ai/modules/minimax-bot.js
@@ -99,8 +99,8 @@ var getBestMove = exports.getBestMove = (battle, decisions) => {
                 ourMoves: ourMoves,
                 theirMoves: theirMoves,
                 ourStats: ourBaseStats,
-                ourLevel: ourPokemon.level,
-                theirLevel: foePokemon.level
+                ourDetails: ourDetails,
+                theirLevel: foePokemon.level,
                 ourTypes: ourTypes,
                 theirTypes: foePokemon.template.types,
                 ourBaseStats: ourPokemon.template.baseStats,
@@ -121,7 +121,7 @@ var getBestMove = exports.getBestMove = (battle, decisions) => {
                 formatName(decision[0].move) == action[1]
             )[0]
             console.log("Minimax Move: ", newDecision[0].move)
-            
+
             return newDecision
         } else if (action[0] == "switch") {
             // switch returned

--- a/Pokemon-Showdown/Pokemon-Showdown-Bot/package.json
+++ b/Pokemon-Showdown/Pokemon-Showdown-Bot/package.json
@@ -43,9 +43,9 @@
   "private": true,
   "license": "MIT",
   "dependencies": {
-    "colors": "1.0.3",
-    "sugar": "^1.4.1",
-    "websocket": "1.0.18"
+    "colors": "^1.0.3",
+    "sugar": "^1.5.0",
+    "websocket": "^1.0.28"
   },
   "devDependencies": {
     "cache-swap": "~0.2.0",

--- a/Pokemon-Showdown/sim/minimaxserver.py
+++ b/Pokemon-Showdown/sim/minimaxserver.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from pprint import pprint
 
 from flask import Flask
 from flask import request
@@ -14,24 +15,14 @@ app = Flask(__name__)
 def get_action():
     data = request.data
     dataDict = json.loads(data)
-    theirHpStatus = dataDict['theirHp'].split(" ") # theirHpStatus[0] is hp, [1] is status effect
+    pprint(dataDict)
 
     # Enemy Pokemon Info
-    if len(theirHpStatus) == 2:
-        theirHp = theirHpStatus[0].split("/")
-        dataDict['theirHp'] = float(theirHp[0]) / float(theirHp[1])
-        dataDict['theirMaxHp'] = int(theirHp[1])
-        dataDict['theirStatus'] = theirHpStatus[1]
-    else:
-        theirHp = theirHpStatus[0].split("/")
-        dataDict['theirHp'] = float(theirHp[0]) / float(theirHp[1])
-        dataDict['theirMaxHp'] = int(theirHp[1])
-        dataDict['theirStatus'] = "None"
+    theirHp = float(dataDict['theirHp']) # theirHpStatus[0] is hp, [1] is status effect
+    theirStatus = dataDict['theirStatus'] if dataDict['theirStatus'] != "False" else None
     # print("Their details are", dataDict["theirDetails"])
     # if "Mime" in dataDict["theirDetails"]:
     #  dataDict["theirDetails"].replace(" Mime", "Mime")
-    theirLevelInfo = dataDict['theirDetails'].split(", ")
-    dataDict["theirLevel"] = int(theirLevelInfo[1][1:])
 
     # Our Team Info
     dataDict['ourMaxHp'] = {}
@@ -73,16 +64,11 @@ def get_action():
             ourCurrStats = list(dataDict['ourStats'][key].values())
             # keyrint(dataDict['ourStatus'])
             # print("base stats are ", dataDict['ourBaseStats'])
-            ourBaseStats = list(dataDict['ourBaseStats'][key].values())
-            ourStatMultiplier = {}
-            for i in range(len(dataDict["ourTypes"][key])):
-                dataDict["ourTypes"][key][i] = dataDict["ourTypes"][key][i].lower()
-            for i in range(len(ourCurrStats)):
-                ourStatMultiplier[i] = float(ourCurrStats[i]) / float(ourBaseStats[i])
+            ourStatMultiplier = dataDict['ourBoosts']
             pokemonTeam[key] = (
                 dataDict["ourPokemon"][key],
                 ourCurrStats,
-                dataDict['ourMaxHp'][key],
+                dataDict['ourStats'][key]['hp'],
                 dataDict['ourLevel'][key],
                 dataDict['ourHp'][key],
                 dataDict['ourMoves'][key],
@@ -90,19 +76,13 @@ def get_action():
                 dataDict['ourStatus'][key],
                 ourStatMultiplier
             )
-    theirCurrStats = list(dataDict["theirStats"].values())
-    theirBaseStats = list(dataDict["theirBaseStats"][str(dataDict['theirPokemon'])].values())
-    theirStatMultiplier = {}
-    for i in range(len(dataDict["theirTypes"])):
-        dataDict["theirTypes"][i] = dataDict["theirTypes"][i].lower()
-    for i in range(len(theirCurrStats)):
-        theirStatMultiplier[i] = float(theirCurrStats[i]) / float(theirBaseStats[i])
-
-    # print("Team: ",pokemonTeam)
+    theirCurrStats = list(dataDict["theirBaseStats"].values())
+    theirStatMultiplier = dataDict['theirBoosts']
+    print("Team: ",pokemonTeam)
     enemy = (
         dataDict['theirPokemon'],
         theirCurrStats,
-        dataDict['theirMaxHp'],
+        dataDict['theirBaseStats']['hp'],
         dataDict["theirLevel"],
         dataDict['theirHp'],
         list(dataDict['theirMoves']),
@@ -110,7 +90,7 @@ def get_action():
         dataDict["theirStatus"],
         theirStatMultiplier
     )
-    # print("Enemy: ",enemy)
+    print("Enemy: ",enemy)
     team_poke = {}  # dictionary containing our team's pokemon objects
     # print("generation is ", type(generation))
     for p in pokemonTeam.keys():
@@ -119,10 +99,10 @@ def get_action():
             ally[0],
             ally[1][0],  # att
             ally[1][1],  # def
-            ally[1][2],  # sp att
-            ally[1][3],  # sp def
-            ally[1][4],  # speed
-            ally[2],  # max hp
+            ally[1][3],  # sp att
+            ally[1][4],  # sp def
+            ally[1][5],  # speed
+            ally[1][2],  # max hp
             ally[3],  # level
             ally[4],  # curr hp
             generation,
@@ -136,10 +116,10 @@ def get_action():
         enemy[0],
         enemy[1][0],  # att
         enemy[1][1],  # def
-        enemy[1][2],  # sp att
-        enemy[1][3],  # sp def
-        enemy[1][4],  # speed
-        enemy[2],  # max hp
+        enemy[1][3],  # sp att
+        enemy[1][4],  # sp def
+        enemy[1][5],  # speed
+        enemy[1][2],  # max hp
         enemy[3],  # level
         enemy[4],  # curr hp
         generation,

--- a/Pokemon-Showdown/sim/pysim/pokemon_simple.py
+++ b/Pokemon-Showdown/sim/pysim/pokemon_simple.py
@@ -62,11 +62,11 @@ class Pokemon:
             self.status[status] = 1.0
         else:
             self.status = {"brn": 0, "frz": 0, "par": 0, "psn": 0, "slp": 0, "tox": 0}
-        self.atk_stage = list(stat_multipliers.values())[0] - 1
-        self.def_stage = list(stat_multipliers.values())[1] - 1
-        self.spa_stage = list(stat_multipliers.values())[2] - 1
-        self.spd_stage = list(stat_multipliers.values())[3] - 1
-        self.spe_stage = list(stat_multipliers.values())[4] - 1
+        self.atk_stage = stat_multipliers.get('atk', 0)
+        self.def_stage = stat_multipliers.get('def', 0)
+        self.spa_stage = stat_multipliers.get('spa', 0)
+        self.spd_stage = stat_multipliers.get('spd', 0)
+        self.spe_stage = stat_multipliers.get('spe', 0)
         #self._tox_stage = _tox_stage
 
     def stage_to_multiplier(self, stage):
@@ -147,7 +147,7 @@ class Pokemon:
 
 def calcEffectiveness(move, defendingPokemon):
     effectivenesses = [move_effectiveness[(
-        move.type, def_type)] for def_type in defendingPokemon.types]
+        move.type, def_type.lower())] for def_type in defendingPokemon.types]
     effectiveness = 1
     for e in effectivenesses:
         effectiveness = effectiveness * e


### PR DESCRIPTION
foePokemon bug fix. New object passed in POST request:

{
    generation: GEN,
    currPokemon: POKEDEX[getPokemonName(currPokemon)].num,
    ourPokemon: ourPokedexNumbers,
    theirPokemon: POKEDEX[foeName].num,
    ourHp: ourCondition,
    theirHp: foePokemon.hp/100,
    ourMoves: ourMoves,
    theirMoves: theirMoves,
    ourStats: ourBaseStats,
    ourDetails: ourDetails,
    theirLevel: foePokemon.level
    ourTypes: ourTypes,
    theirTypes: foePokemon.template.types,
    ourBaseStats: ourPokemon.template.baseStats,
    theirBaseStats: foePokemon.template.baseStats,
    ourBoosts: ourPokemon.boosts,
    theirBoosts: ourPokemon.boosts
}

theirHp is now their hp as a number between 0 and 100
ourStats no longer holds boosted stats, but an object mapping each of our pokemon's pokedex numbers to their base stats
We no longer pass in theirDetails: 'Pokemon, L79'. Instead we pass in theirLevel: '79'
ourBaseStats contains only the base stats of our current pokemon
theirBaseStats contains a list of their pokemon's base stats
ourBoosts is an object mapping stat to boost ('spd': '1', 'spa': '-1'}
theirBoosts is similar but for opponent pokemon